### PR TITLE
Set proper optional resolution for javax.xml.catalog

### DIFF
--- a/jaxb-ri/bundles/osgi/osgi/pom.xml
+++ b/jaxb-ri/bundles/osgi/osgi/pom.xml
@@ -330,7 +330,7 @@
                                     javax.swing.border,
                                     javax.swing.tree,
                                     javax.tools,
-                                    javax.xml.catalog;optional=true,
+                                    javax.xml.catalog;resolution:=optional,
                                     javax.xml.datatype,
                                     javax.xml.namespace,
                                     javax.xml.parsers,


### PR DESCRIPTION
I'm not sure but this prevents me from using the bundle. I think it is not the correct form.